### PR TITLE
Dev/carlfsmithiii

### DIFF
--- a/echo.py
+++ b/echo.py
@@ -29,6 +29,8 @@ def main(args):
     output_string = ' '.join(args.text)
     if args.upper:
         print(output_string.upper())
+    elif args.lower:
+        print(output_string.lower())
 
 
 if __name__ == '__main__':

--- a/echo.py
+++ b/echo.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """An enhanced version of the 'echo' cmd line utility"""
 
-__author__ = "???"
+__author__ = "Carl Smith"
 
 
 import argparse
@@ -35,6 +35,7 @@ def main(args):
         output_string = output_string.title()
 
     print(output_string)
+
 
 if __name__ == '__main__':
     parser = create_parser()

--- a/echo.py
+++ b/echo.py
@@ -13,8 +13,9 @@ def create_parser():
     """Creates and returns an argparse cmd line option parser"""
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.",
+        usage="echo.py [-h] [-u] [-l] [-t] text"
     )
-    parser.add_argument('text', help="text to be manipulated")
+    parser.add_argument('text', nargs='+', help="text to be manipulated")
     parser.add_argument('-u', '--upper', action="store_true",
                         help='convert text to uppercase')
     parser.add_argument('-l', '--lower', action="store_true",

--- a/echo.py
+++ b/echo.py
@@ -14,20 +14,23 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.")
     parser.add_argument('text', help="text to be manipulated")
-    parser.add_argument('-u', '--upper', action="store_true",
+    parser.add_argument('-u', '--upper', action="store_const", const="upper",
                         help='convert text to uppercase')
     parser.add_argument('-l', '--lower', action="store_true",
                         help='convert text to lowercase')
     parser.add_argument('-t', '--title', action="store_true",
                         help='convert text to titlecase')
-    args = parser.parse_args()
-    return args
+    return parser
+    # args = parser.parse_args()
+    # return args
 
 
 def main(args):
     """Implementation of echo"""
-    pass
+    print(args)
 
 
 if __name__ == '__main__':
-    main(create_parser())
+    parser = create_parser()
+    args = parser.parse_args(sys.argv[1:])
+    main(args)

--- a/echo.py
+++ b/echo.py
@@ -28,14 +28,13 @@ def main(args):
     """Implementation of echo"""
     output_string = ' '.join(args.text)
     if args.upper:
-        print(output_string.upper())
-    elif args.lower:
-        print(output_string.lower())
-    elif args.title:
-        print(output_string.title())
-    else:
-        print(output_string)
+        output_string = output_string.upper()
+    if args.lower:
+        output_string = output_string.lower()
+    if args.title:
+        output_string = output_string.title()
 
+    print(output_string)
 
 if __name__ == '__main__':
     parser = create_parser()

--- a/echo.py
+++ b/echo.py
@@ -14,9 +14,12 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.")
     parser.add_argument('text', help="text to be manipulated")
-    parser.add_argument('-u', '--upper', action="store_true", help='convert text to uppercase')
-    parser.add_argument('-l', '--lower', action="store_true", help='convert text to lowercase')
-    parser.add_argument('-t', '--title', action="store_true", help='convert text to titlecase')
+    parser.add_argument('-u', '--upper', action="store_true",
+                        help='convert text to uppercase')
+    parser.add_argument('-l', '--lower', action="store_true",
+                        help='convert text to lowercase')
+    parser.add_argument('-t', '--title', action="store_true",
+                        help='convert text to titlecase')
     args = parser.parse_args()
     return args
 

--- a/echo.py
+++ b/echo.py
@@ -5,12 +5,20 @@
 __author__ = "???"
 
 
+import argparse
 import sys
 
 
 def create_parser():
     """Creates and returns an argparse cmd line option parser"""
-    pass
+    parser = argparse.ArgumentParser(
+        description="Perform transformation on input text.")
+    parser.add_argument('text', help="text to be manipulated")
+    parser.add_argument('-u', '--upper', help='convert text to uppercase')
+    parser.add_argument('-l', '--lower', help='convert text to lowercase')
+    parser.add_argument('-t', '--title', help='convert text to titlecase')
+    args = parser.parse_args()
+    return args
 
 
 def main(args):
@@ -19,4 +27,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    pass
+    main(create_parser())

--- a/echo.py
+++ b/echo.py
@@ -14,7 +14,7 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.")
     parser.add_argument('text', help="text to be manipulated")
-    parser.add_argument('-u', '--upper', action="store_const", const="upper",
+    parser.add_argument('-u', '--upper', action="store_true",
                         help='convert text to uppercase')
     parser.add_argument('-l', '--lower', action="store_true",
                         help='convert text to lowercase')

--- a/echo.py
+++ b/echo.py
@@ -31,6 +31,10 @@ def main(args):
         print(output_string.upper())
     elif args.lower:
         print(output_string.lower())
+    elif args.title:
+        print(output_string.title())
+    else:
+        print(output_string)
 
 
 if __name__ == '__main__':

--- a/echo.py
+++ b/echo.py
@@ -14,9 +14,9 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.")
     parser.add_argument('text', help="text to be manipulated")
-    parser.add_argument('-u', '--upper', help='convert text to uppercase')
-    parser.add_argument('-l', '--lower', help='convert text to lowercase')
-    parser.add_argument('-t', '--title', help='convert text to titlecase')
+    parser.add_argument('-u', '--upper', action="store_true", help='convert text to uppercase')
+    parser.add_argument('-l', '--lower', action="store_true", help='convert text to lowercase')
+    parser.add_argument('-t', '--title', action="store_true", help='convert text to titlecase')
     args = parser.parse_args()
     return args
 

--- a/echo.py
+++ b/echo.py
@@ -13,8 +13,8 @@ def create_parser():
     """Creates and returns an argparse cmd line option parser"""
     parser = argparse.ArgumentParser(
         description="Perform transformation on input text.",
-        usage='%(prog)s [-h] [-u] [-l] [-t] text')
-    parser.add_argument('text', nargs="+", help="text to be manipulated")
+    )
+    parser.add_argument('text', help="text to be manipulated")
     parser.add_argument('-u', '--upper', action="store_true",
                         help='convert text to uppercase')
     parser.add_argument('-l', '--lower', action="store_true",

--- a/echo.py
+++ b/echo.py
@@ -12,8 +12,8 @@ import sys
 def create_parser():
     """Creates and returns an argparse cmd line option parser"""
     parser = argparse.ArgumentParser(
-        description="Perform transformation on input text.")
-    parser.add_argument('text', help="text to be manipulated")
+        description="Perform transformation on input text.", usage='%(prog)s [-h] [-u] [-l] [-t] text')
+    parser.add_argument('text', nargs="+", help="text to be manipulated")
     parser.add_argument('-u', '--upper', action="store_true",
                         help='convert text to uppercase')
     parser.add_argument('-l', '--lower', action="store_true",
@@ -27,7 +27,9 @@ def create_parser():
 
 def main(args):
     """Implementation of echo"""
-    print(args)
+    output_string = ' '.join(args.text)
+    if args.upper:
+        print(output_string.upper())
 
 
 if __name__ == '__main__':

--- a/echo.py
+++ b/echo.py
@@ -12,7 +12,8 @@ import sys
 def create_parser():
     """Creates and returns an argparse cmd line option parser"""
     parser = argparse.ArgumentParser(
-        description="Perform transformation on input text.", usage='%(prog)s [-h] [-u] [-l] [-t] text')
+        description="Perform transformation on input text.",
+        usage='%(prog)s [-h] [-u] [-l] [-t] text')
     parser.add_argument('text', nargs="+", help="text to be manipulated")
     parser.add_argument('-u', '--upper', action="store_true",
                         help='convert text to uppercase')
@@ -21,8 +22,6 @@ def create_parser():
     parser.add_argument('-t', '--title', action="store_true",
                         help='convert text to titlecase')
     return parser
-    # args = parser.parse_args()
-    # return args
 
 
 def main(args):

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -33,10 +33,12 @@ class EchoTest(unittest.TestCase):
             output UPPER case text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-u", "test"]
+            ["python", "./echo.py", "-u", " ", "test"],
+            stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertEquals(stdout, "TEST")
+        self.assertIn("TEST", stdout)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -55,24 +55,23 @@ class EchoTest(unittest.TestCase):
         )
         stdout, _ = process.communicate()
         self.assertIn("test", stdout)
-        
-    # def test_lower_option_parser_output(self):
-    #     """ Parsing '-l' or '--lower' should store "lower" in namespace """
-    #     parser = echo.create_parser()
-    #     args = parser.parse_args(['echo.py', '-u'])
-    #     self.assertTrue(args.upper)
 
-    # def test_upper_case_output(self):
-    #     """ Running the program with '-u' or '--upper' 
-    #         output UPPER case text 
-    #     """
-    #     process = subprocess.Popen(
-    #         ["python", "./echo.py", "-u", " ", "test"],
-    #         stdout=subprocess.PIPE
-    #     )
-    #     stdout, _ = process.communicate()
-    #     self.assertIn("TEST", stdout)
-    
+    def test_title_option_parser_output(self):
+        """ Parsing '-t' or '--title' should store "title" in namespace """
+        parser = echo.create_parser()
+        args = parser.parse_args(['echo.py', '-t'])
+        self.assertTrue(args.title)
+
+    def test_title_case_output(self):
+        """ Running the program with '-t' or '--title' 
+            output Title case Text 
+        """
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-t", " ", "test"],
+            stdout=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        self.assertIn("Test", stdout)
 
 
 if __name__ == '__main__':

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -72,7 +72,7 @@ class EchoTest(unittest.TestCase):
         )
         stdout, _ = process.communicate()
         self.assertEquals("Test This", stdout.strip())
-    
+
     def test_multiple_options(self):
         """ Test cases where multiple flags (-t, -u, -l) are selected.
             -l trumps -u and -t trumps both
@@ -91,7 +91,16 @@ class EchoTest(unittest.TestCase):
         stdout, _ = process.communicate()
         self.assertEquals("hello!", stdout.strip())
 
-
+    def test_output_is_not_altered_when_no_arguments(self):
+        """ Tests that the input text is returned 
+            when no arguments provided 
+        """
+        process = subprocess.Popen(
+            ["python", "./echo.py", "a", "TesT"],
+            stdout=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        self.assertEquals('a TesT', stdout.strip())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -2,9 +2,25 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import subprocess
 import echo
 
 # Your test case class goes here
+
+
+class EchoTest(unittest.TestCase):
+    def test_help(self):
+        """ Running the program without arguments should show usage. """
+
+        # Run the command `python ./echo.py -h` in a separate process, then
+        # collect it's output.
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-h"],
+            stdout=subprocess.PIPE)
+        stdout, _ = process.communicate()
+        usage = open("./USAGE", "r").read()
+
+        self.assertEquals(stdout, usage)
 
 
 if __name__ == '__main__':

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -67,11 +67,11 @@ class EchoTest(unittest.TestCase):
             output Title case Text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-t", "test"],
+            ["python", "./echo.py", "-t", "test", "this"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertEquals("Test", stdout.strip())
+        self.assertEquals("Test This", stdout.strip())
 
 
 if __name__ == '__main__':

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -29,8 +29,8 @@ class EchoTest(unittest.TestCase):
         self.assertTrue(args.upper)
 
     def test_upper_case_output(self):
-        """ Running the program with '-u' or '--upper' 
-            output UPPER case text 
+        """ Running the program with '-u' or '--upper'
+            output UPPER case text
         """
         process = subprocess.Popen(
             ["python", "./echo.py", "-u", "test", "this"],
@@ -46,8 +46,8 @@ class EchoTest(unittest.TestCase):
         self.assertTrue(args.lower)
 
     def test_lower_case_output(self):
-        """ Running the program with '-l' or '--lower' 
-            output lower case text 
+        """ Running the program with '-l' or '--lower'
+            output lower case text
         """
         process = subprocess.Popen(
             ["python", "./echo.py", "-l", "TEST", "THIS"],
@@ -63,8 +63,8 @@ class EchoTest(unittest.TestCase):
         self.assertTrue(args.title)
 
     def test_title_case_output(self):
-        """ Running the program with '-t' or '--title' 
-            output Title case Text 
+        """ Running the program with '-t' or '--title'
+            output Title case Text
         """
         process = subprocess.Popen(
             ["python", "./echo.py", "-t", "test", "this"],
@@ -92,8 +92,8 @@ class EchoTest(unittest.TestCase):
         self.assertEquals("hello!", stdout.strip())
 
     def test_output_is_not_altered_when_no_arguments(self):
-        """ Tests that the input text is returned 
-            when no arguments provided 
+        """ Tests that the input text is returned
+            when no arguments provided
         """
         process = subprocess.Popen(
             ["python", "./echo.py", "a", "TesT"],
@@ -101,6 +101,7 @@ class EchoTest(unittest.TestCase):
         )
         stdout, _ = process.communicate()
         self.assertEquals('a TesT', stdout.strip())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -33,11 +33,11 @@ class EchoTest(unittest.TestCase):
             output UPPER case text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-u", "test"],
+            ["python", "./echo.py", "-u", "test", "this"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertEquals("TEST", stdout.strip())
+        self.assertEquals("TEST THIS", stdout.strip())
 
     def test_lower_option_parser_output(self):
         """ Parsing '-l' or '--lower' should store "lower" in namespace """
@@ -50,11 +50,11 @@ class EchoTest(unittest.TestCase):
             output lower case text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-l", "TEST"],
+            ["python", "./echo.py", "-l", "TEST", "THIS"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertEquals("test", stdout.strip())
+        self.assertEquals("test this", stdout.strip())
 
     def test_title_option_parser_output(self):
         """ Parsing '-t' or '--title' should store "title" in namespace """

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -28,9 +28,15 @@ class EchoTest(unittest.TestCase):
         args = parser.parse_args(['echo.py', '-u'])
         self.assertTrue(args.upper)
 
-    # def test_upper_case_output(self):
-    #     """ Running the program with '-u' or '--upper' 
-
+    def test_upper_case_output(self):
+        """ Running the program with '-u' or '--upper' 
+            output UPPER case text 
+        """
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-u", "test"]
+        )
+        stdout, _ = process.communicate()
+        self.assertEquals(stdout, "TEST")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -22,6 +22,15 @@ class EchoTest(unittest.TestCase):
 
         self.assertEquals(stdout, usage)
 
+    def test_upper_option_parser_output(self):
+        """ Parsing '-u' or '--upper' should store "upper" in namespace """
+        parser = echo.create_parser()
+        args = parser.parse_args(['echo.py', '-u'])
+        self.assertTrue(args.upper)
+
+    # def test_upper_case_output(self):
+    #     """ Running the program with '-u' or '--upper' 
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -72,6 +72,25 @@ class EchoTest(unittest.TestCase):
         )
         stdout, _ = process.communicate()
         self.assertEquals("Test This", stdout.strip())
+    
+    def test_multiple_options(self):
+        """ Test cases where multiple flags (-t, -u, -l) are selected.
+            -l trumps -u and -t trumps both
+        """
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-t", "-l", "-u", "heLLo!"],
+            stdout=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        self.assertEquals("Hello!", stdout.strip())
+
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-l", "-u", "heLLo!"],
+            stdout=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        self.assertEquals("hello!", stdout.strip())
+
 
 
 if __name__ == '__main__':

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -39,6 +39,41 @@ class EchoTest(unittest.TestCase):
         stdout, _ = process.communicate()
         self.assertIn("TEST", stdout)
 
+    def test_lower_option_parser_output(self):
+        """ Parsing '-l' or '--lower' should store "lower" in namespace """
+        parser = echo.create_parser()
+        args = parser.parse_args(['echo.py', '-l'])
+        self.assertTrue(args.lower)
+
+    def test_lower_case_output(self):
+        """ Running the program with '-l' or '--lower' 
+            output lower case text 
+        """
+        process = subprocess.Popen(
+            ["python", "./echo.py", "-l", " ", "TEST"],
+            stdout=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        self.assertIn("test", stdout)
+        
+    # def test_lower_option_parser_output(self):
+    #     """ Parsing '-l' or '--lower' should store "lower" in namespace """
+    #     parser = echo.create_parser()
+    #     args = parser.parse_args(['echo.py', '-u'])
+    #     self.assertTrue(args.upper)
+
+    # def test_upper_case_output(self):
+    #     """ Running the program with '-u' or '--upper' 
+    #         output UPPER case text 
+    #     """
+    #     process = subprocess.Popen(
+    #         ["python", "./echo.py", "-u", " ", "test"],
+    #         stdout=subprocess.PIPE
+    #     )
+    #     stdout, _ = process.communicate()
+    #     self.assertIn("TEST", stdout)
+    
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -33,11 +33,11 @@ class EchoTest(unittest.TestCase):
             output UPPER case text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-u", " ", "test"],
+            ["python", "./echo.py", "-u", "test"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertIn("TEST", stdout)
+        self.assertEquals("TEST", stdout.strip())
 
     def test_lower_option_parser_output(self):
         """ Parsing '-l' or '--lower' should store "lower" in namespace """
@@ -50,11 +50,11 @@ class EchoTest(unittest.TestCase):
             output lower case text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-l", " ", "TEST"],
+            ["python", "./echo.py", "-l", "TEST"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertIn("test", stdout)
+        self.assertEquals("test", stdout.strip())
 
     def test_title_option_parser_output(self):
         """ Parsing '-t' or '--title' should store "title" in namespace """
@@ -67,11 +67,11 @@ class EchoTest(unittest.TestCase):
             output Title case Text 
         """
         process = subprocess.Popen(
-            ["python", "./echo.py", "-t", " ", "test"],
+            ["python", "./echo.py", "-t", "test"],
             stdout=subprocess.PIPE
         )
         stdout, _ = process.communicate()
-        self.assertIn("Test", stdout)
+        self.assertEquals("Test", stdout.strip())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I don't feel truly comfortable with some of the tricks I pulled to get the help formatting to match that provided in the USAGE file.  For instance, I hard coded the 'usage' in the ArgumentParser call in order to get rid of an extra '[...text]'.  Also, I used the provided test for "running the program without arguments", but this test actually supplies the -h argument.  I did not find an acceptable way to get the help text displayed on invalid arguments, such as -q.